### PR TITLE
Update character count to work with wrapped inputs

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
@@ -165,7 +165,12 @@ CharacterCount.prototype.init = function () {
 
   // Move the textarea description to be immediately after the textarea
   // Kept for backwards compatibility
-  $textarea.insertAdjacentElement('afterend', $textareaDescription)
+  var $inputWrapper = this.$module.querySelector('.govuk-input__wrapper')
+  if ($inputWrapper) {
+    $inputWrapper.insertAdjacentElement('afterend', $textareaDescription)
+  } else {
+    $textarea.insertAdjacentElement('afterend', $textareaDescription)
+  }
 
   // Create the *screen reader* specific live-updating counter
   // This doesn't need any styling classes, as it is never visible


### PR DESCRIPTION
If the character count component is used on a text input, that contains a prefix or suffix the textareaDescription is incorrectly placed.

As it gets inserted immediately after the $textarea element (input) this means it is within the input wrapper flex container.

Check for the presence of a `.govuk-input__wrapper` element, and if it exists, insert the description after the wrapper element.